### PR TITLE
Add pipeline for global_mangrove_watch

### DIFF
--- a/stactools_pipelines/cdk/inventory.py
+++ b/stactools_pipelines/cdk/inventory.py
@@ -84,6 +84,7 @@ class Inventory(Construct):
                     "s3:Get*",
                     "s3:List*",
                     "s3:ListBucket",
+                    "s3:PutObject",
                 ],
             )
         )

--- a/stactools_pipelines/pipelines/global_mangrove_watch/app.py
+++ b/stactools_pipelines/pipelines/global_mangrove_watch/app.py
@@ -23,7 +23,7 @@ def handler(event: SQSEvent, context):
         keys = json.loads(record["body"])
         try:
             item = create_item(**keys)
-            item.collection = COLLECTION_ID
+            item.collection_id = COLLECTION_ID
         except Exception as e:
             print(f"Failed to create item for {keys}: {e}")
             continue

--- a/stactools_pipelines/pipelines/global_mangrove_watch/app.py
+++ b/stactools_pipelines/pipelines/global_mangrove_watch/app.py
@@ -4,6 +4,7 @@ import os
 import requests
 from aws_lambda_powertools.utilities.data_classes import SQSEvent, event_source
 from pystac import set_stac_version
+from stactools.global_mangrove_watch.constants import COLLECTION_ID
 from stactools.global_mangrove_watch.stac import create_item
 
 from stactools_pipelines.cognito.utils import get_token
@@ -22,6 +23,7 @@ def handler(event: SQSEvent, context):
         keys = json.loads(record["body"])
         try:
             item = create_item(**keys)
+            item.collection = COLLECTION_ID
         except Exception as e:
             print(f"Failed to create item for {keys}: {e}")
             continue

--- a/stactools_pipelines/pipelines/global_mangrove_watch/app.py
+++ b/stactools_pipelines/pipelines/global_mangrove_watch/app.py
@@ -1,0 +1,38 @@
+import json
+import os
+
+import requests
+from aws_lambda_powertools.utilities.data_classes import SQSEvent, event_source
+from pystac import set_stac_version
+from stactools.global_mangrove_watch.stac import create_item
+
+from stactools_pipelines.cognito.utils import get_token
+
+set_stac_version("1.0.0")
+
+
+@event_source(data_class=SQSEvent)
+def handler(event: SQSEvent, context):
+    """handler for generating items"""
+    ingestor_url = os.environ["INGESTOR_URL"]
+    ingestions_endpoint = f"{ingestor_url.strip('/')}/ingestions"
+    token = get_token()
+    headers = {"Authorization": f"bearer {token}"}
+    for record in event.records:
+        keys = json.loads(record["body"])
+        try:
+            item = create_item(**keys)
+        except Exception as e:
+            print(f"Failed to create item for {keys}: {e}")
+            continue
+
+        response = requests.post(
+            url=ingestions_endpoint,
+            data=json.dumps(item.to_dict()),
+            headers=headers,
+        )
+        try:
+            response.raise_for_status()
+        except Exception:
+            print(response.text)
+            raise

--- a/stactools_pipelines/pipelines/global_mangrove_watch/collection.py
+++ b/stactools_pipelines/pipelines/global_mangrove_watch/collection.py
@@ -1,0 +1,40 @@
+import json
+import os
+
+import requests
+from pystac import Provider, ProviderRole, set_stac_version
+from stactools.global_mangrove_watch.stac import create_collection
+
+from stactools_pipelines.cognito.utils import get_token
+
+set_stac_version("1.0.0")
+
+
+def handler(event, context):
+    """handler for collection upload"""
+    ingestor_url = os.environ["INGESTOR_URL"]
+    collections_endpoint = f"{ingestor_url.strip('/')}/collections"
+    token = get_token()
+    headers = {"Authorization": f"bearer {token}"}
+
+    collection = create_collection()
+    collection.providers.append(
+        Provider(
+            name="NASA MAAP",
+            url="https://maap-project.org/",
+            roles=[
+                ProviderRole.HOST,
+            ],
+        )
+    )
+    response = requests.post(
+        url=collections_endpoint,
+        data=json.dumps(collection.to_dict()),
+        headers=headers,
+    )
+
+    try:
+        response.raise_for_status()
+    except Exception:
+        print(response.text)
+        raise

--- a/stactools_pipelines/pipelines/global_mangrove_watch/config.yaml
+++ b/stactools_pipelines/pipelines/global_mangrove_watch/config.yaml
@@ -1,0 +1,7 @@
+---
+  id: "global_mangrove_watch"
+  compute: "awslambda"
+  secret_arn: "arn:aws:secretsmanager:us-west-2:916098889494:secret:MAAP-STAC-auth-dev/MAAP-workflows-EsykqB" # cognito secret ARN
+  ingestor_url: "https://stac-ingestor.dit.maap-project.org"
+  historic_frequency: 0
+

--- a/stactools_pipelines/pipelines/global_mangrove_watch/config.yaml
+++ b/stactools_pipelines/pipelines/global_mangrove_watch/config.yaml
@@ -3,5 +3,6 @@
   compute: "awslambda"
   secret_arn: "arn:aws:secretsmanager:us-west-2:916098889494:secret:MAAP-STAC-auth-dev/MAAP-workflows-EsykqB" # cognito secret ARN
   ingestor_url: "https://stac-ingestor.dit.maap-project.org"
+  inventory_location: "https://zenodo.org/records/6894273" # placeholder
   historic_frequency: 0
 

--- a/stactools_pipelines/pipelines/global_mangrove_watch/historic.py
+++ b/stactools_pipelines/pipelines/global_mangrove_watch/historic.py
@@ -83,7 +83,7 @@ def generate_inventory() -> defaultdict[str, dict[str, str]]:
                 zip_ref.extractall(temp_dir)
 
             for root, _, files in os.walk(temp_dir):
-                for filename in sorted(files)[:10]:
+                for filename in sorted(files):
                     if filename.endswith(".tif"):
                         # Parse filename
                         try:

--- a/stactools_pipelines/pipelines/global_mangrove_watch/historic.py
+++ b/stactools_pipelines/pipelines/global_mangrove_watch/historic.py
@@ -2,6 +2,9 @@
 
 Download the zip files from Zenodo and upload COGs to S3, then pass sets of
 asset hrefs to the item processing step.
+
+HR: I had to run the generate_inventory function outside of the pipeline because
+it would time out on the Lambda otherwise :/
 """
 
 import json

--- a/stactools_pipelines/pipelines/global_mangrove_watch/historic.py
+++ b/stactools_pipelines/pipelines/global_mangrove_watch/historic.py
@@ -1,0 +1,126 @@
+"""Prepare historic inventory for processing.
+
+Download the zip files from Zenodo and upload COGs to S3, then pass sets of
+asset hrefs to the item processing step.
+"""
+
+import json
+import os
+import re
+import tempfile
+import urllib.request
+import zipfile
+from collections import defaultdict
+
+import boto3
+from botocore.exceptions import ClientError
+
+ZIP_URL_FORMAT = "https://zenodo.org/records/6894273/files/gmw_v3_{group}_gtiff.zip"
+
+BASE_YEAR = 1996
+YEARS = [
+    2007,
+    2008,
+    2009,
+    2010,
+    2015,
+    2016,
+    2017,
+    2018,
+    2019,
+    2020,
+]
+ALL_GROUPS = [str(year) for year in [BASE_YEAR] + YEARS] + [
+    f"f{BASE_YEAR}_t{year}" for year in YEARS
+]
+
+DESTINATION_BUCKET = "nasa-maap-data-store"
+DESTINATION_PREFIX = "file-staging/nasa-map/global-mangrove-watch/v3"
+
+
+def parse_filename(filename: str) -> tuple[str, str]:
+    """
+    Parse GMW filename and return (base_key, full_filename)
+    """
+    # Pattern for change files: GMW_N27W110_chng_f1996_t2020_v3.tif
+    change_pattern = r"(GMW_[NS]\d+[WE]\d+)_chng_f\d+_t(\d+)_v3\.tif"
+
+    # Pattern for base files: GMW_N27W110_2020_v3.tif
+    base_pattern = r"(GMW_[NS]\d+[WE]\d+)_(\d+)_v3\.tif"
+
+    # Try change pattern first
+    change_match = re.match(change_pattern, filename)
+    if change_match:
+        location, year = change_match.groups()
+        base_key = f"{location}_{year}_v3"
+        return base_key, "change_asset_href"
+
+    # Try base pattern
+    base_match = re.match(base_pattern, filename)
+    if base_match:
+        location, year = base_match.groups()
+        base_key = f"{location}_{year}_v3"
+        return base_key, "cog_asset_href"
+
+    raise ValueError(f"Unrecognized filename pattern: {filename}")
+
+
+def generate_inventory() -> defaultdict[str, dict[str, str]]:
+    """Download zips, upload contents to S3, and return inventory of uploaded files
+    grouped by item ID (cog_asset_href and change_asset_href)."""
+    s3_client = boto3.client("s3")
+    inventory = defaultdict(dict)
+
+    for group in ALL_GROUPS:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            zip_url = ZIP_URL_FORMAT.format(group=group)
+            zip_path = os.path.join(temp_dir, f"gmw_v3_{group}_gtiff.zip")
+
+            print(f"Downloading {zip_url}")
+            urllib.request.urlretrieve(zip_url, zip_path)
+
+            with zipfile.ZipFile(zip_path, "r") as zip_ref:
+                zip_ref.extractall(temp_dir)
+
+            for root, _, files in os.walk(temp_dir):
+                for filename in sorted(files)[:10]:
+                    if filename.endswith(".tif"):
+                        # Parse filename
+                        try:
+                            base_key, arg = parse_filename(filename)
+                        except ValueError as e:
+                            print(f"Warning: {e}")
+                            continue
+
+                        local_path = os.path.join(root, filename)
+                        s3_key = f"{DESTINATION_PREFIX}/{filename}"
+                        href = f"s3://{DESTINATION_BUCKET}/{s3_key}"
+
+                        # Check if file already exists in S3
+                        try:
+                            s3_client.head_object(Bucket=DESTINATION_BUCKET, Key=s3_key)
+                            print(f"File already exists in S3: {s3_key}")
+                            continue
+                        except ClientError as e:
+                            if e.response["Error"]["Code"] == "404":
+                                print(f"Uploading {filename} to {href}")
+                                s3_client.upload_file(
+                                    local_path, DESTINATION_BUCKET, s3_key
+                                )
+                            else:
+                                # If error is not 404, re-raise it
+                                raise
+
+                        inventory[base_key][arg] = href
+            print(f"Completed processing group: {group}")
+
+    return inventory
+
+
+def handler(event, context):
+    """handler for firing messages for historic inventory to the queue"""
+    QUEUE_URL = os.environ["QUEUE_URL"]
+    inventory = generate_inventory()
+    sqs_client = boto3.client("sqs")
+    for keys in inventory.values():
+        sqs_client.send_message(QueueUrl=QUEUE_URL, MessageBody=json.dumps(keys))

--- a/stactools_pipelines/pipelines/global_mangrove_watch/historic.py
+++ b/stactools_pipelines/pipelines/global_mangrove_watch/historic.py
@@ -40,7 +40,7 @@ DESTINATION_PREFIX = "file-staging/nasa-map/global-mangrove-watch/v3"
 
 def parse_filename(filename: str) -> tuple[str, str]:
     """
-    Parse GMW filename and return (base_key, full_filename)
+    Parse GMW filename and return (item_id, arg_name)
     """
     # Pattern for change files: GMW_N27W110_chng_f1996_t2020_v3.tif
     change_pattern = r"(GMW_[NS]\d+[WE]\d+)_chng_f\d+_t(\d+)_v3\.tif"

--- a/stactools_pipelines/pipelines/global_mangrove_watch/requirements.txt
+++ b/stactools_pipelines/pipelines/global_mangrove_watch/requirements.txt
@@ -1,0 +1,5 @@
+stactools-global-mangrove-watch==0.1.0
+aws-lambda-powertools
+boto3
+requests
+

--- a/stactools_pipelines/pipelines/global_mangrove_watch/test_app.py
+++ b/stactools_pipelines/pipelines/global_mangrove_watch/test_app.py
@@ -1,0 +1,31 @@
+import json
+
+import pytest
+
+import stactools_pipelines.pipelines.conftest as conftest
+from stactools_pipelines.pipelines.global_mangrove_watch.app import handler
+
+key = json.dumps(
+    {
+        "cog_asset_href": "s3://path/to/gmw_N00E00_2020_v3.tif",
+        "change_asset_href": "s3://path/to/gmw_N00E00_chng_f1996_t2020_v3.tif",
+    }
+)
+
+
+@pytest.fixture
+def sns_message():
+    yield key
+
+
+@pytest.mark.parametrize("pipeline_id", ["global_mangrove_watch"])
+@pytest.mark.parametrize("module", ["app"])
+def test_handler(mock_env, sns_message, sqs_event, get_token, create_item, requests):
+    handler(sqs_event, {})
+    get_token.assert_called_once()
+    create_item.assert_called_once_with(**json.loads(key))
+    requests.post.assert_called_once_with(
+        url=f"{conftest.ingestor_url}/ingestions",
+        data=json.dumps(conftest.item),
+        headers={"Authorization": f"bearer {conftest.token}"},
+    )

--- a/stactools_pipelines/pipelines/global_mangrove_watch/test_collection.py
+++ b/stactools_pipelines/pipelines/global_mangrove_watch/test_collection.py
@@ -1,0 +1,22 @@
+import json
+
+import pytest
+
+from stactools_pipelines.pipelines import conftest
+from stactools_pipelines.pipelines.global_mangrove_watch.collection import handler
+
+
+@pytest.mark.parametrize("pipeline_id", ["global_mangrove_watch"])
+@pytest.mark.parametrize("module", ["collection"])
+def test_handler(mock_env, get_token, create_collection, requests):
+    handler({}, {})
+    get_token.assert_called_once()
+
+    create_collection.assert_called_once()
+
+    # Check if the post requests were called correctly
+    requests.post.assert_called_once_with(
+        url=f"{conftest.ingestor_url}/collections",
+        data=json.dumps(conftest.collection),
+        headers={"Authorization": f"bearer {conftest.token}"},
+    )

--- a/stactools_pipelines/pipelines/global_mangrove_watch/test_historic.py
+++ b/stactools_pipelines/pipelines/global_mangrove_watch/test_historic.py
@@ -1,0 +1,38 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+import stactools_pipelines.pipelines.conftest as conftest
+from stactools_pipelines.pipelines.global_mangrove_watch.historic import (
+    handler,
+)
+
+keys = {
+    "gmw_N00E00_2020_v3": {
+        "cog_asset_href": "s3://path/to/gmw_N00E00_2020_v3.tif",
+        "change_asset_href": "s3://path/to/gmw_N00E00_chng_f1996_t2020_v3.tif",
+    }
+}
+
+
+@pytest.fixture()
+def generate_inventory():
+    with patch(
+        "stactools_pipelines.pipelines.global_mangrove_watch.historic.generate_inventory",
+        autospec=True,
+    ) as m:
+        m.return_value = keys
+        yield m
+
+
+@pytest.mark.parametrize("pipeline_id", ["global_mangrove_watch"])
+@pytest.mark.parametrize("query_value", [""])
+def test_handler(mock_env, generate_inventory, boto3):
+    handler({}, {})
+    generate_inventory.assert_called_once()
+
+    conftest.sqs_client.send_message.assert_called_once_with(
+        QueueUrl=conftest.queue_url,
+        MessageBody=json.dumps(list(keys.values())[0]),
+    )


### PR DESCRIPTION
I tried a new approach for doing the copy operation: it happens in the `historic.py` module, passes the sets of hrefs off to the item generating function. I will have to double check to make sure the historic function won't time out too soon for it to work!